### PR TITLE
Make satime/sablame dynamic 

### DIFF
--- a/calcstats_json.py
+++ b/calcstats_json.py
@@ -14,6 +14,7 @@ import json
 import statistics
 import os
 import fnmatch
+from collections import OrderedDict
 
 ###############################################################
 # FUNCTIONS Begin
@@ -123,6 +124,21 @@ def print_stats(data_dict, json_path, fname):
         print("> % s  " %(json_path[-1]) +\
               "% s Samples - SKIPPED" %(vl_length)) 
 
+
+# Function to get the list of keys across multiple runs
+def get_test_result_list(data, metric):
+    runs = [results['test_results'][metric] for results in data]
+    keys_list = []
+    for items in runs:
+        for item_key in items:
+            keys_list.append(item_key)
+
+    unique_keys = list(dict.fromkeys(keys_list))
+
+    return unique_keys
+
+
+
 # FUNCTIONS End
 ###############################################################
 
@@ -138,25 +154,19 @@ for filename in os.listdir(dir):
             # now open it, load JSON and print the stats
             with open(f, 'r') as file:
                 data = json.load(file)
+
                 print("## " + f)
                 print("systemd-analyze time:")
-                satime_list = ["kernel", "initrd", "userspace", "total"]
+                satime_list = get_test_result_list(data, "satime")
+
                 for key1 in satime_list:
                     print_stats(data,\
                       ["test_results", "satime", key1], filename)
 
+
                 print("systemd-analyze blame:")
-                sablame_list = ["NetworkManager-wait-online.service", \
-                        "initrd-switch-root.service", \
-                        "initrd-cleanup.service", \
-                        "NetworkManager.service", \
-                        "auditd.service", \
-                        "systemd-tmpfiles-setup.service", \
-                        "dbus-broker.service", \
-                        "user@0.service", \
-                        "chronyd.service", \
-                        "systemd-logind.service", \
-                        "systemd-udevd.service"]
+                sablame_list = get_test_result_list(data, "sablame")
+
                 for key2 in sablame_list:
                     print_stats(data,\
                       ["test_results", "sablame", key2], filename)

--- a/calcstats_json.py
+++ b/calcstats_json.py
@@ -104,9 +104,9 @@ def print_stats(data_dict, json_path, fname):
         else:
             pass
 
-    # Check for empty list, if so skip it
+    # Check for a list with less than 2 values, if so skip it
     vl_length = len(value_list)
-    if vl_length:
+    if vl_length > 1:
         # Print MEAN, STDDEV and %SD aka co-efficient of variation
         mean = statistics.mean(value_list)
         std_dev = statistics.stdev(value_list)

--- a/sut_boottest.py
+++ b/sut_boottest.py
@@ -5,25 +5,21 @@
 # Tested on CentOS Stream 8 - Python 3.6.8.
 # DEPENDENCIES: # python3 -m pip install paramiko
 #
-# Edit SUT VARS section for your test environment systems
-#
-
-#####################################
-# SUT VARS
-#      >> EDIT THIS LIST FOR YOUR ENVIRONMENT <<
-#
-#      "hostname" , "ipAddr" , "user", "password"
-sut_list = [
-    ("system1", "192.168.0.100", "root", "password"),
-    ("system2", "192.168.0.101", "root", "password"),
-]
-run_count = 5        # how many test-runs to conduct for each SUT
-
 # Set this to your systems network-link-is-up string found in DMESG
+# net_str = [
+#         '"Link is Up"',
+#         '"link is up"',
+#         '"link is ready"',
+#         '"link becomes ready"',
+#         '"eth0"',
+#         ]
+
+
 #net_str = '"link is up"'            # RHIVOS ER1 on RPI4
 #net_str = '"link is ready"'         # RHIVOS ER1.2 on RPI4
 net_str = '"link becomes ready"'    # RHIVOS ER1.2 on QDrive3
 #net_str = '"eth0"'                  # RHIVOS ER2 on QDrive3
+#net_str = '"Link is Up"'                  # RHIVOS ER3 on QDrive3
 
 #####################################
 # DICTIONARY Format - dicts initialized in main()
@@ -59,6 +55,8 @@ import re
 import datetime
 import json
 import io
+import argparse
+
 
 #####################################
 # CLASSES
@@ -91,6 +89,41 @@ class Timer:
 
 #####################################
 # FUNCTIONS
+def parse_args():
+    parser = argparse.ArgumentParser(\
+            description='Reboots remote systems (SUTs) and captures boot timing results')
+
+    parser.add_argument(
+            'hostname',
+            help='Description of device to run boot time tests',
+            )
+    parser.add_argument(
+            'ip',
+            help='IP address of device to run boot time tests',
+            )
+    parser.add_argument(
+            'username',
+            nargs='?',
+            default='root',
+            help='Username to login to device',
+            )
+    parser.add_argument(
+            'password',
+            nargs='?',
+            default='password',
+            help='Password to login to device',
+            )
+    parser.add_argument(
+            '-s',
+            '--samples',
+            type=int,
+            default='1',
+            help='Password to login to device',
+            )
+
+    return parser.parse_args()
+
+
 def write_json(thedict, thefile):
     to_unicode = str
    # Write JSON file
@@ -539,7 +572,7 @@ def phase5(ip, usr, passwd):
     return ph5_dict
 
 #####################################
-# GLOBAL VARS
+# GLOBAL VARS 
 target = "multi-user.target"  # graphical.target
 reboot_timeout = 300          # max. number of seconds: rebootsut()
 ssh_timeout = 20              # max. number of seconds: testssh()
@@ -551,99 +584,106 @@ retry_int = 2                 # client.connect retry interval (in sec)
 def main():
     blame_cnt = 10            # number of sablame services to record
 
+    
+    # Parse CLI args and assign them to their respective variables
+    args = parse_args()
+    (sut_host, sut_ip, sut_usr, sut_pswd) = (
+            args.hostname, args.ip, args.username, args.password 
+            )
+    run_count = args.samples
+
     ##########################
     # OUTER LOOP - For each SUT
-    for i, (sut_host, sut_ip, sut_usr, sut_pswd) in enumerate(sut_list):
-        # initialize vars and print msg for this SUT being tested
-        print(f'\n***SUT: {sut_ip}  {sut_host}  Number of Runs: {run_count}***')
-        results_list = []          # comprehensive results - list of dicts
-        outfilename = str(sut_host + "_" +\
-                      datetime.datetime.now().strftime('%m_%d_%Y_%H_%M_%S') +\
-                      ".json")
-        run_number = 1          # initialize
-        while run_number <= run_count:
-            print(f'\n** Run: {run_number} **')
-            
-            # Dictionaries
-            testrun_dict = {}        # complete testrun results (per SUT)
-            testcfg_dict = {}        # test configuration
-            syscfg_dict = {}         # system configuration
-            data_dict = {}           # testdata results (nested)
-
-            # Verify connectivity to SUT
-            ping_ssh1 = testssh(sut_ip, sut_usr, sut_pswd, ssh_timeout)
-            if ping_ssh1 is False:
-                continue            # skip this SUT
-
-            # Add to dict{} for this SUT
-            testrun_dict["cluster_name"] = str(sut_host) 
-            curtime = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-            testrun_dict["date"] = str(curtime.strip())
-            testrun_dict["test_type"] = "boot-time"   # hardcoded
-            testrun_dict["sample"] = int(run_number)
-
-            # Initialize testcfg dict{} for this SUT
-            testcfg_dict = init_dict(
-                sut_host, sut_ip, reboot_timeout, ssh_timeout, target, blame_cnt)
-            testrun_dict["test_config"] = testcfg_dict
-
-            ############
-            # INNER LOOP
-            # Proceed through testing phases
-            #----------
-            # Phase 1: gather system facts
-            print(f'*Phase 1 - gather facts')
-            syscfg_dict = phase1(sut_ip, sut_usr, sut_pswd)
-
-            #----------
-            # Phase 2: configure SUT for reboot
-            # returns if neptuneui (boolean) is running
-            print(f'*Phase 2 - configure SUT for reboot')
-            neptuneui = phase2(sut_ip, sut_usr, sut_pswd, target)
-
-            #----------
-            # Phase 3: initiate reboot, wait for system readiness
-            #          and record timing results into reboot_dict{}
-            print(f'*Phase 3 - initiate reboot and wait for system readiness')
-            reboot_dict = phase3(sut_ip, sut_usr, sut_pswd)
-            # Verify connectivity to freshly rebooted SUT
-            ping_ssh2 = testssh(sut_ip, sut_usr, sut_pswd, ssh_timeout)
-            if ping_ssh2 is False:
-                continue           # reboot failed, abort this SUT test
-
-            #----------
-            # Phase 4: instrument SUT reboot w/systemd-analyze commands
-            # NOTE: sa_dict is nested with "sa_time" and "sa_blame" keys
-            print(f'*Phase 4 - record systemd-analyze reboot stats')
-            sa_dict = phase4(sut_ip, sut_usr, sut_pswd, blame_cnt)
-
-            #----------
-            # Phase 5: neptune UI startup timings
-            print(f'*Phase 5 - neptune timing stats (if available)')
-            neptuneui_dict = phase5(sut_ip, sut_usr, sut_pswd)
-
-            ######################
-            # All PHASEs for this SUT completed
-            # Insert existing test results into 'test_results' section
-            data_dict["reboot"] = reboot_dict
-            data_dict["satime"] = sa_dict["sa_time"]
-            data_dict["sablame"] = sa_dict["sa_blame"]
-            data_dict["neptuneui"] = neptuneui_dict
-
-            # Insert complete data_dict{} into testrun_dict (final dictionary)
-            testrun_dict["test_results"] = data_dict
-
-            # Insert syscfg_dict{} into testrun_dict{}
-            testrun_dict["system_config"] = syscfg_dict
+    # initialize vars and print msg for this SUT being tested
+    print(f'\n***SUT: {sut_ip}  {sut_host}  Number of Runs: {run_count}***')
+    results_list = []          # comprehensive results - list of dicts
+    outfilename = str(sut_host + "_" +\
+                  datetime.datetime.now().strftime('%m_%d_%Y_%H_%M_%S') +\
+                  ".json")
+    run_number = 1          # initialize
+    while run_number <= run_count:
+        print(f'\n** Run: {run_number} **')
         
-            # Insert test results for this SUT into results_list[]
-            results_list.append(testrun_dict)
+        # Dictionaries
+        testrun_dict = {}        # complete testrun results (per SUT)
+        testcfg_dict = {}        # test configuration
+        syscfg_dict = {}         # system configuration
+        data_dict = {}           # testdata results (nested)
 
-            run_number += 1          # incr run cntr
+        # Verify connectivity to SUT
+        ping_ssh1 = testssh(sut_ip, sut_usr, sut_pswd, ssh_timeout)
+        if ping_ssh1 is False:
+            continue            # skip this SUT
 
-        print(f'+++TESTING for {sut_host} COMPLETED+++')
+        # Add to dict{} for this SUT
+        testrun_dict["cluster_name"] = str(sut_host)
+        curtime = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        testrun_dict["date"] = str(curtime.strip())
+        testrun_dict["test_type"] = "boot-time"   # hardcoded
+        testrun_dict["sample"] = int(run_number)
 
-        write_json(results_list, outfilename)
+        # Initialize testcfg dict{} for this SUT
+        testcfg_dict = init_dict(
+            sut_host, sut_ip, reboot_timeout, ssh_timeout, target, blame_cnt)
+        testrun_dict["test_config"] = testcfg_dict
+
+        ############
+        # INNER LOOP
+        # Proceed through testing phases
+        #----------
+        # Phase 1: gather system facts
+        print(f'*Phase 1 - gather facts')
+        syscfg_dict = phase1(sut_ip, sut_usr, sut_pswd)
+
+        #----------
+        # Phase 2: configure SUT for reboot
+        # returns if neptuneui (boolean) is running
+        print(f'*Phase 2 - configure SUT for reboot')
+        neptuneui = phase2(sut_ip, sut_usr, sut_pswd, target)
+
+        #----------
+        # Phase 3: initiate reboot, wait for system readiness
+        #          and record timing results into reboot_dict{}
+        print(f'*Phase 3 - initiate reboot and wait for system readiness')
+        reboot_dict = phase3(sut_ip, sut_usr, sut_pswd)
+        # Verify connectivity to freshly rebooted SUT
+        ping_ssh2 = testssh(sut_ip, sut_usr, sut_pswd, ssh_timeout)
+        if ping_ssh2 is False:
+            continue           # reboot failed, abort this SUT test
+
+        #----------
+        # Phase 4: instrument SUT reboot w/systemd-analyze commands
+        # NOTE: sa_dict is nested with "sa_time" and "sa_blame" keys
+        print(f'*Phase 4 - record systemd-analyze reboot stats')
+        sa_dict = phase4(sut_ip, sut_usr, sut_pswd, blame_cnt)
+
+        #----------
+        # Phase 5: neptune UI startup timings
+        print(f'*Phase 5 - neptune timing stats (if available)')
+        neptuneui_dict = phase5(sut_ip, sut_usr, sut_pswd)
+
+        ######################
+        # All PHASEs for this SUT completed
+        # Insert existing test results into 'test_results' section
+        data_dict["reboot"] = reboot_dict
+        data_dict["satime"] = sa_dict["sa_time"]
+        data_dict["sablame"] = sa_dict["sa_blame"]
+        data_dict["neptuneui"] = neptuneui_dict
+
+        # Insert complete data_dict{} into testrun_dict (final dictionary)
+        testrun_dict["test_results"] = data_dict
+
+        # Insert syscfg_dict{} into testrun_dict{}
+        testrun_dict["system_config"] = syscfg_dict
+
+        # Insert test results for this SUT into results_list[]
+        results_list.append(testrun_dict)
+
+        run_number += 1          # incr run cntr
+
+    print(f'+++TESTING for {sut_host} COMPLETED+++')
+
+    write_json(results_list, outfilename)
         
     print(f'+++TESTING for all systems COMPLETED+++')
 # END MAIN

--- a/sut_boottest.py
+++ b/sut_boottest.py
@@ -105,7 +105,14 @@ def parse_args():
             '--samples',
             type=int,
             default='1',
-            help='Password to login to device',
+            help='Number of samples to collect',
+            )
+    parser.add_argument(
+            '-b',
+            '--blame-count',
+            type=int,
+            default='10',
+            help='Number of services to collect for systemd-analzye blame',
             )
 
     return parser.parse_args()
@@ -576,7 +583,6 @@ retry_int = 2                 # client.connect retry interval (in sec)
 # MAIN
 
 def main():
-    blame_cnt = 10            # number of sablame services to record
 
     
     # Parse CLI args and assign them to their respective variables
@@ -585,6 +591,7 @@ def main():
             args.hostname, args.ip, args.username, args.password 
             )
     run_count = args.samples
+    blame_cnt = args.blame_count
 
     ##########################
     # OUTER LOOP - For each SUT


### PR DESCRIPTION
- Made the list for satime and sablame dynamic.
- Fixed crash when there is only a single sample, now requires at least 2 samples to calculate statistics.
[orig-results.txt](https://github.com/jharriga/BootTime/files/12242440/orig-results.txt)
[dynamic-results.txt](https://github.com/jharriga/BootTime/files/12242442/dynamic-results.txt)
- Added CLI args to sut_boottime.py and calc_stats.py
- Added more generic `net_str` to sut_bootttime.py and error reporting on failure.
